### PR TITLE
fix: add pragma once

### DIFF
--- a/shared/installer.hpp
+++ b/shared/installer.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 #include <span>
 #include <variant>


### PR DESCRIPTION
allows beatsaber-hook to include header in hooking.hpp without redefinition error.